### PR TITLE
Fixed the depreciated conversion warnings

### DIFF
--- a/SPG290/scorelibs/TV/TV.c
+++ b/SPG290/scorelibs/TV/TV.c
@@ -128,7 +128,7 @@ void TV_Fade(unsigned int fade){
 // 
 //	void return
 // =============================================================
-void TV_Print(unsigned short *fb, unsigned int x, unsigned int y, char *text){
+void TV_Print(unsigned short *fb, unsigned int x, unsigned int y, const char *text){
 	
     short xx, yy;
     unsigned short colorz;
@@ -156,7 +156,7 @@ void TV_Print(unsigned short *fb, unsigned int x, unsigned int y, char *text){
 // 
 //	void return
 // =============================================================
-void TV_PrintColor(unsigned short *fb, unsigned int x, unsigned int y, char *text, unsigned short color){
+void TV_PrintColor(unsigned short *fb, unsigned int x, unsigned int y, const char *text, unsigned short color){
 	
     short xx, yy;
     while (*text) 

--- a/SPG290/scorelibs/include/TV/TV.h
+++ b/SPG290/scorelibs/include/TV/TV.h
@@ -23,8 +23,8 @@ void TV_Hue(unsigned int hue);
 void TV_Fade(unsigned int fade);
 void TV_FadeIn(void);
 void TV_FadeOut(void);
-void TV_Print(unsigned short *fb, unsigned int x, unsigned int y, char *text);
-void TV_PrintColor(unsigned short *fb, unsigned int x, unsigned int y, char *text, unsigned short color);
+void TV_Print(unsigned short *fb, unsigned int x, unsigned int y, const char *text);
+void TV_PrintColor(unsigned short *fb, unsigned int x, unsigned int y, const char *text, unsigned short color);
 void TV_PrintHex(unsigned short *fb, unsigned intx,  unsigned int y, unsigned long value);
 
 #ifdef __cplusplus


### PR DESCRIPTION
I fixed the issue with the compiler warning "warning: deprecated conversion from string constant to ‘char*’" by changing the text argument from char *text to const char *text in the TV_Print and TV_PrintColor functions.